### PR TITLE
:whale: Drop superuser priviliges in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,7 +61,7 @@ RUN mkdir /app/log
 COPY --from=frontend-build /app/src/verzoeken/static/css /app/src/verzoeken/static/css
 COPY ./src /app/src
 
-RUN useradd -M -u 1000 user
+RUN adduser -D -H -u 1000  user
 RUN chown -R user /app
 
 # drop privileges

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,13 @@ RUN mkdir /app/log
 
 COPY --from=frontend-build /app/src/verzoeken/static/css /app/src/verzoeken/static/css
 COPY ./src /app/src
+
+RUN useradd -M -u 1000 user
+RUN chown -R user /app
+
+# drop privileges
+USER user
+
 ARG COMMIT_HASH
 ENV GIT_SHA=${COMMIT_HASH}
 


### PR DESCRIPTION
to ensure that containers can be run as non-root users

Alpine uses the command adduser and addgroup for creating users and groups (rather than useradd and usergroup).

Local docker-compose:

```
Step 25/34 : RUN adduser -D -H -u 1000  user
 ---> Running in bfe6ae052bb1
Removing intermediate container bfe6ae052bb1
 ---> 283188b372af
Step 26/34 : RUN chown -R user /app
 ---> Running in 4d56d7c5c502
```

